### PR TITLE
feat(ci): Add gh action workflows for rust agent helm charts

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,5 @@
+chart-dirs:
+- rust/helm
+check-version-increment: false
+target-branch: main
+validate-maintainers: false

--- a/.github/workflows/rust-helm-release.yml
+++ b/.github/workflows/rust-helm-release.yml
@@ -1,0 +1,30 @@
+name: Release Agent Helm Chart to Github Page
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  helm-chart-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: rust/helm/
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/rust-helm-test.yml
+++ b/.github/workflows/rust-helm-test.yml
@@ -1,0 +1,25 @@
+name: Test Agent Helm Chart
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - '**'
+    paths:
+      - 'rust/helm/**'
+  pull_request:
+    paths:
+      - 'rust/helm/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install ct
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run lint
+        run: ct lint --config .github/ct.yaml


### PR DESCRIPTION
### Description

This PR includes Github action workflows for test and release of rust agent helm charts

### Drive-by changes

_Are there any minor or drive-by changes also included?_

### Related issues

- Fixes #[issue number here]

### Backward compatibility

_Are these changes backward compatible?_

Yes
No

_Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?_

None
Yes


### Testing

_What kind of testing have these changes undergone?_

None
Manual
Unit Tests
